### PR TITLE
New: Add support to split strings in handlebar templates (ref #199)

### DIFF
--- a/src/handlebar-helpers.js
+++ b/src/handlebar-helpers.js
@@ -23,6 +23,14 @@ const helpers = {
   },
   or() {
     return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+  },
+  split(data, delimiter) {
+    if (typeof data === 'string' && typeof delimiter === 'string') {
+      if (delimiter !== "") {
+        return data.split(delimiter)
+      }
+    }
+    return []
   }
 };
 

--- a/src/handlebar-helpers.js
+++ b/src/handlebar-helpers.js
@@ -26,11 +26,11 @@ const helpers = {
   },
   split(data, delimiter) {
     if (typeof data === 'string' && typeof delimiter === 'string') {
-      if (delimiter !== "") {
-        return data.split(delimiter)
+      if (delimiter !== '') {
+        return data.split(delimiter);
       }
     }
-    return []
+    return [];
   }
 };
 

--- a/src/handlebar-helpers.js
+++ b/src/handlebar-helpers.js
@@ -24,7 +24,7 @@ const helpers = {
   or() {
     return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
   },
-  split(data, delimiter) {
+  split: function (data, delimiter) {
     if (typeof data === 'string' && typeof delimiter === 'string') {
       if (delimiter !== '') {
         return data.split(delimiter);

--- a/src/handlebar-helpers.js
+++ b/src/handlebar-helpers.js
@@ -26,11 +26,9 @@ const helpers = {
   },
   split: function (data, delimiter) {
     if (typeof data === 'string' && typeof delimiter === 'string') {
-      if (delimiter !== '') {
-        return data.split(delimiter);
-      }
+      return data.split(delimiter);
     }
-    return [];
+    return [data];
   }
 };
 

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -66,4 +66,26 @@ describe('handlebar-helper', function () {
         ret = HandlebarHelper.split(undefined, ":")
         assert.equal(1, ret.length, 'there is no split')
     });
+    it('should say that true and true is true', function () {
+        ret = HandlebarHelper.and(true, true)
+        assert.equal(true, ret, "and returns true when passed in true and true")
+    });
+    it('should say that true and false is false', function () {
+        ret = HandlebarHelper.and(true, false)
+        assert.equal(false, ret, "and returns false when passed in true and false")
+    });
+    it('should say that true or true is true', function () {
+        ret = HandlebarHelper.or(true, true)
+        assert.equal(true, ret, "or returns true when passed in true and true")
+    });
+    it('should say that true or false is true', function () {
+        ret = HandlebarHelper.or(true, false)
+        assert.equal(true, ret, "or returns true when passed in true and false")
+    });
+    it('should assign value correctly', function () {
+        var data = 'key'
+        var options = []
+        ret = HandlebarHelper.assign(data, 'what', options)
+        assert.equal(options.data.root[data], 'what', "assign works correctly")
+    });
 });

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -50,9 +50,9 @@ describe('handlebar-helper', function () {
         assert.equal('10.10.10.10', ret[0], 'ip address is 10.10.10.10')
         assert.equal('400', ret[1], 'port is 400')
     });
-    it('should not correctly split ip:port when delimiter is empty', function () {
+    it('should correctly split on every character when delimiter is empty', function () {
         ret = HandlebarHelper.split("10.10.10.10:400", "")
-        assert.equal(15, ret.length, 'there is no split')
+        assert.equal(15, ret.length, 'should split on every character')
     });
     it('should not correctly split when delimiter is not string or data is not string', function () {
         ret = HandlebarHelper.split("10.10.10.10:400", 10)

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -1,0 +1,63 @@
+var assert = require('chai').assert;
+var HandlebarHelper = require('../src/handlebar-helpers');
+describe('handlebar-helper', function () {
+    it('should correctly say that 40 > 30 using gt', function () {
+        ret = HandlebarHelper.gt(40, 30)
+        assert.equal(ret, true, '40 is greater than 30)');
+        ret = HandlebarHelper.gt(30, 40)
+        assert.equal(ret, false, '30 is not greater than 40)');
+    });
+    it('should correctly say that 30 < 40 using lt', function () {
+        ret = HandlebarHelper.lt(30, 40)
+        assert.equal(ret, true, '30 is less than 40)');
+        ret = HandlebarHelper.lt(40, 30)
+        assert.equal(ret, false, '40 is not less than 30)');
+    });
+    it('should correctly say that 30 = 30 using eq and ne', function () {
+        ret = HandlebarHelper.eq(30, 30)
+        assert.equal(ret, true, '30 is equal to 30)');
+        ret = HandlebarHelper.ne(30, 30)
+        assert.equal(ret, false, '30 is not ne 30)');
+    });
+    it('should correctly say that 40 != 30 using eq and ne', function () {
+        ret = HandlebarHelper.eq(40, 30)
+        assert.equal(ret, false, '40 is not equal to 30)');
+        ret = HandlebarHelper.ne(40, 30)
+        assert.equal(ret, true, '40 is ne 30)');
+    });
+    it('should correctly say that 30 >= 30 using gte', function () {
+        ret = HandlebarHelper.gte(30, 30)
+        assert.equal(ret, true, '30 is greater than or equal to 30)');
+    });
+    it('should correctly say that 30 <= 30 using lte', function () {
+        ret = HandlebarHelper.lte(30, 30)
+        assert.equal(ret, true, '30 is less than or equal to 30)');
+    });
+    it('should correctly say that 40 > 30 using gte', function () {
+        ret = HandlebarHelper.gt(40, 30)
+        assert.equal(ret, true, '40 is greater than 30)');
+        ret = HandlebarHelper.gt(30, 40)
+        assert.equal(ret, false, '30 is not greater than 40)');
+    });
+    it('should correctly say that 30 < 40 using lte', function () {
+        ret = HandlebarHelper.lt(30, 40)
+        assert.equal(ret, true, '30 is less than 40)');
+        ret = HandlebarHelper.lt(40, 30)
+        assert.equal(ret, false, '40 is not less than 30)');
+    });
+    it('should correctly split ip:port when delimiter is :', function () {
+        ret = HandlebarHelper.split("10.10.10.10:400", ":")
+        assert.equal('10.10.10.10', ret[0], 'ip address is 10.10.10.10')
+        assert.equal('400', ret[1], 'port is 400')
+    });
+    it('should not correctly split ip:port when delimiter is empty', function () {
+        ret = HandlebarHelper.split("10.10.10.10:400", "")
+        assert.equal(0, ret.length, 'there is no split')
+    });
+    it('should not correctly split when delimiter is not string or data is not string', function () {
+        ret = HandlebarHelper.split("10.10.10.10:400", 10)
+        assert.equal(0, ret.length, 'there is no split')
+        ret = HandlebarHelper.split(1000, "")
+        assert.equal(0, ret.length, 'there is no split')
+    });
+});

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -82,6 +82,10 @@ describe('handlebar-helper', function () {
         ret = HandlebarHelper.or(true, false)
         assert.equal(true, ret, "or returns true when passed in true and false")
     });
+    it('should say that false or false is false', function () {
+        ret = HandlebarHelper.or(false, false)
+        assert.equal(false, ret, "or returns false when passed in false and false")
+    });
     it('should assign value correctly', function () {
         var data = 'key'
         var options = []

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -52,12 +52,18 @@ describe('handlebar-helper', function () {
     });
     it('should not correctly split ip:port when delimiter is empty', function () {
         ret = HandlebarHelper.split("10.10.10.10:400", "")
-        assert.equal(0, ret.length, 'there is no split')
+        assert.equal(15, ret.length, 'there is no split')
     });
     it('should not correctly split when delimiter is not string or data is not string', function () {
         ret = HandlebarHelper.split("10.10.10.10:400", 10)
-        assert.equal(0, ret.length, 'there is no split')
+        assert.equal(1, ret.length, 'there is no split')
         ret = HandlebarHelper.split(1000, "")
-        assert.equal(0, ret.length, 'there is no split')
+        assert.equal(1, ret.length, 'there is no split')
+    });
+    it('should not correctly split when delimiter is undefined', function () {
+        ret = HandlebarHelper.split("10.10.10.10:400", undefined)
+        assert.equal(1, ret.length, 'there is no split')
+        ret = HandlebarHelper.split(undefined, ":")
+        assert.equal(1, ret.length, 'there is no split')
     });
 });


### PR DESCRIPTION
Adding support to be able to split strings using a delimiter and return the split data as a string array.