### PR TITLE
feat(handlebars): add helper to pick first non nullish value

### DIFF
--- a/src/handlebar-helpers.js
+++ b/src/handlebar-helpers.js
@@ -19,11 +19,11 @@ const helpers = {
   gt: (v1, v2) => v1 > v2,
   lte: (v1, v2) => v1 <= v2,
   gte: (v1, v2) => v1 >= v2,
-  and() {
-    return Array.prototype.every.call(arguments, Boolean);
+  and(...args) {
+    return args.every(Boolean);
   },
-  or() {
-    return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+  or(...args) {
+    return args.slice(0, -1).some(Boolean);
   },
   split: function (data, delimiter) {
     if (typeof data === 'string' && typeof delimiter === 'string') {
@@ -83,6 +83,14 @@ const helpers = {
   jsonDoubleStringify: function (data, space) {
     // if you want to use this, you must use our strTemplate, and you must not put quotes around your template (ie. `my-field: {{ jsonStringify my-json }}` is valid but `my-field: "{{ jsonStringify my-json }}"` is not)
     return JSON.stringify(JSON.stringify(data, null, space));
+  },
+  pick: function (...args) {
+    return args.find((value) => {
+      if (value === null) return false;
+      if (value === undefined) return false;
+      if (value === '') return false;
+      return true;
+    });
   }
 };
 

--- a/test/handlebar-helpers.js
+++ b/test/handlebar-helpers.js
@@ -453,4 +453,26 @@ describe('handlebar-helpers', function () {
     });
   });
 
+  describe('#pick()', function() {
+    it('should omit null and undefined values', function () {
+      let ret = HandlebarHelper.pick(null, undefined, []);
+      assert.deepEqual(ret, [], 'Should return empty array');
+    });
+
+    it('should omit empty string values', function () {
+      let ret = HandlebarHelper.pick(null, undefined, '', [], 100);
+      assert.deepEqual(ret, [], 'Should return empty array');
+    });
+
+    it('should find finite numerical values', function () {
+      let ret = HandlebarHelper.pick(null, 0, undefined, []);
+      assert.equal(ret, 0, 'Should return 0');
+    });
+
+    it('should find string literal "null"', function () {
+      let ret = HandlebarHelper.pick(null, undefined, 'null', []);
+      assert.equal(ret, 'null', 'Should return "null"');
+    });
+  });
+
 });


### PR DESCRIPTION
Mustache engine has implicit lexical scoping where referecing a variable
by name may actually pull a value from a parent scope

```json
{
  "one": 1
  "two": [
    {"name": "foo", "one": 1}
  , {"name": "bar"}
  ]
}
```

```hbs
{{#two}}
  {{one}}
{{/two}}
```
with the mustach engine, this would print

```txl
1
1
```

as it will reference the parent scope if it is missing from the loop
context.

handlebars has strict context scope and will not do this automatically

```txl
1

```

The pick helper will allow one to specify multiple values for a context
variable and construct valid scope that resembles what mustache does

```hbs
{{#each two}}
  {{#with (pick one @root.one) as |one|}}
    {{one}}
  {{/with}}
{{/each}}
```

```txl
1
1
```