### PR TITLE
fix: restore index.js controller exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,5 +71,6 @@ async function run() {
 }
 
 module.exports = {
-  run
+  run,
+  MustacheTemplateController: Controller
 };


### PR DESCRIPTION
a user described how this is useful for testing without needing to set up an actual environment, so i am putting it back in.