### PR TITLE
feat(resource): allow matchLabels for keyRef abscense of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ spec:
           name: nginx-config-dev
           key: my-app-config-dev-overrides
           type: json
+    - name: json-merge-selectors
+      overrideStrategy: merge
+      valueFrom:
+        configMapKeyRef:
+          matchLabels:
+            app: json-rules-merge
+          key: json-config
+          type: json
   templates:
   - apiVersion: v1
     kind: ConfigMap
@@ -354,7 +362,9 @@ env:
         properties:
           configMapKeyRef:
             type: object
-            required: [name, key]
+            oneOf:
+              - required: [key, name]
+              - required: [key, matchLabels]
             properties:
               name:
                 type: string
@@ -365,9 +375,14 @@ env:
               type:
                 type: string
                 enum: [number, boolean, json, jsonString, base64]
+              matchLabels:
+                type: object
+                additionalProperties: true
           secretKeyRef:
             type: object
-            required: [name, key]
+            oneOf:
+              - required: [key, name]
+              - required: [key, matchLabels]
             properties:
               name:
                 type: string
@@ -378,9 +393,14 @@ env:
               type:
                 type: string
                 enum: [number, boolean, json, jsonString, base64]
+              matchLabels:
+                type: object
+                additionalProperties: true
           genericKeyRef:
             type: object
-            required: [apiVersion, kind, name, key]
+            oneOf:
+              - required: [apiVersion, kind, name, key]
+              - required: [apiVersion, kind, matchLabels, key]
             properties:
               apiVersion:
                 type: string
@@ -395,6 +415,9 @@ env:
               type:
                 type: string
                 enum: [number, boolean, json, jsonString, base64]
+              matchLabels:
+                type: object
+                additionalProperties: true
 ```
 
 #### Env Optional

--- a/kubernetes/MustacheTemplate/resource.yaml
+++ b/kubernetes/MustacheTemplate/resource.yaml
@@ -233,7 +233,9 @@ items:
                             properties:
                               configMapKeyRef:
                                 type: object
-                                required: [name, key]
+                                oneOf:
+                                  - required: [key, name]
+                                  - required: [key, matchLabels]
                                 properties:
                                   name:
                                     type: string
@@ -244,9 +246,15 @@ items:
                                   type:
                                     type: string
                                     enum: [number, boolean, json, jsonString, base64]
+                                  matchLabels:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties: true
                               secretKeyRef:
                                 type: object
-                                required: [name, key]
+                                oneOf:
+                                  - required: [key, name]
+                                  - required: [key, matchLabels]
                                 properties:
                                   name:
                                     type: string
@@ -257,9 +265,15 @@ items:
                                   type:
                                     type: string
                                     enum: [number, boolean, json, jsonString, base64]
+                                  matchLabels:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties: true
                               genericKeyRef:
                                 type: object
-                                required: [apiVersion, kind, name, key]
+                                oneOf:
+                                  - required: [apiVersion, kind, name, key]
+                                  - required: [apiVersion, kind, matchLabels, key]
                                 properties:
                                   apiVersion:
                                     type: string
@@ -274,6 +288,10 @@ items:
                                   type:
                                     type: string
                                     enum: [number, boolean, json, jsonString, base64]
+                                  matchLabels:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties: true
                     templates:
                       type: array
                       items:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@razee/kubernetes-util": "^0.3.1",
-        "@razee/razeedeploy-core": "^0.13.1",
+        "@razee/razeedeploy-core": "^0.14.1",
         "handlebars": "^4.7.7",
         "js-yaml": "^4.1.0",
         "mustache": "^4.2.0",
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@razee/razeedeploy-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.13.1.tgz",
-      "integrity": "sha512-gxDgsndWJN0tRHxFaNOmH5+PQBTzPJ6eP/Augo5ayGNCnVX8n3JQ8PfJUzzOxwHx6tNlB0UNnQd07BwoL999tw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.14.1.tgz",
+      "integrity": "sha512-5jRv6JaB6Is9XJaqGtiVpvbz3uKRA9SXjFGX+i0S6wUXhqAkBRIOp4gkeuDdXxGh2VTBvo5tOjl+F+kSLrV9Lw==",
       "dependencies": {
         "bunyan": "^1.8.15",
         "clone": "^2.1.2",
@@ -8744,9 +8744,9 @@
       }
     },
     "@razee/razeedeploy-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.13.1.tgz",
-      "integrity": "sha512-gxDgsndWJN0tRHxFaNOmH5+PQBTzPJ6eP/Augo5ayGNCnVX8n3JQ8PfJUzzOxwHx6tNlB0UNnQd07BwoL999tw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.14.1.tgz",
+      "integrity": "sha512-5jRv6JaB6Is9XJaqGtiVpvbz3uKRA9SXjFGX+i0S6wUXhqAkBRIOp4gkeuDdXxGh2VTBvo5tOjl+F+kSLrV9Lw==",
       "requires": {
         "bunyan": "^1.8.15",
         "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@razee/kubernetes-util": "^0.3.1",
-    "@razee/razeedeploy-core": "^0.13.1",
+    "@razee/razeedeploy-core": "^0.14.1",
     "handlebars": "^4.7.7",
     "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",


### PR DESCRIPTION
Expands the schema for configMapKeyRef, secretKeyRef, and genericKeyRef
to allow for label selectors when name is not present. This will allow
for the discovery of resources when trying to merge individual keys
together

Fixes: #296