### PR TITLE
Feat[Breaking]: Additive merge patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ spec:
   clusterAuth:
     impersonateUser: razeedeploy
   envFrom:
-  - genericMapRef:
-      apiVersion: deploy.razee.io/v1alpha2
-      kind: FeatureFlagSetLD
-      name: myLDProject
-      namespace: default
+    - genericMapRef:
+        apiVersion: deploy.razee.io/v1alpha2
+        kind: FeatureFlagSetLD
+        name: myLDProject
+        namespace: default
   env:
     - name: app-label
       value: "deployment 1"
@@ -70,14 +70,14 @@ spec:
           key: json-config
           type: json
   templates:
-  - apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: test-config
-    data:
-      sample: "{{ desired-replicas }}"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-config
+      data:
+        sample: "{{ desired-replicas }}"
   strTemplates:
-  - |
+    - |
       apiVersion: apps/v1
       kind: Deployment
       metadata:
@@ -481,11 +481,11 @@ overrideStrategy:
 
 - DEFAULT: `true`
   - A razeedeploy resource (parent) will clean up a resources it applies (child)
-when either the child is no longer in the parent resource definition or the
-parent is deleted.
+    when either the child is no longer in the parent resource definition or the
+    parent is deleted.
 - `false`
   - This behavior can be overridden when a child's resource definition has
-the label `deploy.razee.io/Reconcile=false`.
+    the label `deploy.razee.io/Reconcile=false`.
 
 #### Resource Update Mode
 
@@ -497,24 +497,35 @@ overridden when a child's resource definition has the label
 
 Mode options:
 
-- DEFAULT: `MergePatch`
+- DEFAULT: `Apply` (`MergePatch`)
   - A simple merge, that will merge objects and replace arrays. Items previously
-  defined, then removed from the definition, will be removed from the live resource.
+    defined, then removed from the definition, will be removed from the live resource.
   - "As defined in [RFC7386](https://tools.ietf.org/html/rfc7386), a Merge Patch
-  is essentially a partial representation of the resource. The submitted JSON is
-  "merged" with the current resource to create a new one, then the new one is
-  saved. For more details on how to use Merge Patch, see the RFC." [Reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#patch-operations)
+    is essentially a partial representation of the resource. The submitted JSON is
+    "merged" with the current resource to create a new one, then the new one is
+    saved. For more details on how to use Merge Patch, see the RFC." [Reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#patch-operations)
 - `StrategicMergePatch`
   - A more complicated merge, the kubernetes apiServer has defined keys to be
-  able to intelligently merge arrays it knows about.
+    able to intelligently merge arrays it knows about.
   - "Strategic Merge Patch is a custom implementation of Merge Patch. For a
-  detailed explanation of how it works and why it needed to be introduced, see
-  [StrategicMergePatch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md)."
-  [Reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#patch-operations)
+    detailed explanation of how it works and why it needed to be introduced, see
+    [StrategicMergePatch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md)."
+    [Reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#patch-operations)
   - [Kubectl Apply Semantics](https://kubectl.docs.kubernetes.io/pages/app_management/field_merge_semantics.html)
+- `AdditiveMergePatch`
+  - Similar to the default `Apply` (`MergePatch`), this is a simple merge, that
+    will merge objects and replace arrays. The difference is that it will
+    not remove fields from the live resource when they are removed from the
+    definition. eg. This will only add/update fields, it wont remove fields.
+  - If you are using this mode and find that you need to remove a field, you can
+    do so manually, by setting the field in the yaml defintion to have a value
+    of `null`. When the null value is merged with the live resource, it will
+    effectively delete the field.
+  - This mode is useful if you have very large resources and require that the
+    `last-applied-configuration` annotation is not injected into the resource.
 - `EnsureExists`
   - Will ensure the resource is created and is replaced if deleted. Will not
-  enforce a definition.
+    enforce a definition.
 
 ### Debug Individual Resource
 
@@ -538,5 +549,6 @@ controller pods so the deployment can mount the ConfigMap as a volume. If the
 
 1. `export CONTROLLER_NAME=mustachetemplate-controller && export CONTROLLER_NAMESPACE=razee`
 1. `kubectl create cm razeedeploy-config -n $CONTROLLER_NAMESPACE --from-literal=lock-cluster=true`
-1. `kubectl delete pods -n $CONTROLLER_NAMESPACE $(kubectl get pods -n $CONTROLLER_NAMESPACE
- | grep $CONTROLLER_NAME | awk '{print $1}' | paste -s -d ',' -)`
+1. `kubectl delete pods -n $CONTROLLER_NAMESPACE $(kubectl get pods -n`
+   `$CONTROLLER_NAMESPACE | grep $CONTROLLER_NAME | awk '{print $1}'`
+   `| paste -s -d ',' -)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@razee/kubernetes-util": "^1.0.0",
-        "@razee/razeedeploy-core": "^0.15.0",
+        "@razee/razeedeploy-core": "^1.0.0",
         "handlebars": "^4.7.7",
         "js-yaml": "^4.1.0",
         "mustache": "^4.2.0",
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@razee/razeedeploy-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.15.0.tgz",
-      "integrity": "sha512-9XK7zZLuZ19UHVMIBdvrzSnxr9z0ylW/ZcoOIYDW/fw10JHuhM9OOBK3CqY4/uCjL4JfsDL/RCyrwmZR3qKOQQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-1.0.0.tgz",
+      "integrity": "sha512-bdufEfn+dQ9vuEwxeindaocHjUtrWEP03XYiaBeu1PHE6YPnfl/BVwqWcMw5UxbXTodiAJLHLWfDFo/CCef4pw==",
       "dependencies": {
         "bunyan": "^1.8.15",
         "clone": "^2.1.2",
@@ -6490,9 +6490,9 @@
       }
     },
     "@razee/razeedeploy-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.15.0.tgz",
-      "integrity": "sha512-9XK7zZLuZ19UHVMIBdvrzSnxr9z0ylW/ZcoOIYDW/fw10JHuhM9OOBK3CqY4/uCjL4JfsDL/RCyrwmZR3qKOQQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-1.0.0.tgz",
+      "integrity": "sha512-bdufEfn+dQ9vuEwxeindaocHjUtrWEP03XYiaBeu1PHE6YPnfl/BVwqWcMw5UxbXTodiAJLHLWfDFo/CCef4pw==",
       "requires": {
         "bunyan": "^1.8.15",
         "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@razee/kubernetes-util": "^1.0.0",
-    "@razee/razeedeploy-core": "^0.15.0",
+    "@razee/razeedeploy-core": "^1.0.0",
     "handlebars": "^4.7.7",
     "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",


### PR DESCRIPTION
allow user to define label `deploy.razee.io/mode: AdditiveMergePatch` on a child resource to avoid razeedeploy setting the `last-applied-configuration` annotation on said child resource.

Removes support of old `kapitan` naming for label/annotations.