### PR TITLE
feat(ci): publish CRD spec as JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ services:
   - docker
 
 before_install:
+  - pyenv install 3.6.15
+  - pyenv global 3.6.15
   - if [[ -v DOCKERHUB_TOKEN ]]; then echo "${DOCKERHUB_TOKEN}" | docker login -u "icdevops" --password-stdin; fi
+  - mkdir -p /tmp/json-schema
 
 script:
   # Audit npm packages. Fail build whan a PR audit fails, otherwise report the vulnerability and proceed.
@@ -18,6 +21,10 @@ script:
   - docker images
   - ./build/process-template.sh kubernetes/MustacheTemplate/resource.yaml >/tmp/resource.yaml
   - if [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then npm version --no-git-tag-version "${TRAVIS_TAG}"; fi
+  - git clone https://github.com/yannh/kubeconform.git /tmp/kubeconform
+  - pip install --user --quiet -r /tmp/kubeconform/scripts/requirements.txt
+  - python /tmp/kubeconform/scripts/openapi2jsonschema.py /tmp/resource.yaml
+  - mv mustachetemplate_*.json /tmp/json-schema/
 
 before_deploy:
   - docker login -u="${QUAY_ID}" -p="${QUAY_TOKEN}" quay.io
@@ -40,6 +47,14 @@ deploy:
       condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
   - provider: releases
     file: /tmp/resource.yaml
+    skip_cleanup: true
+    api_key: "${GITHUB_TOKEN}"
+    name: "${TRAVIS_TAG}"
+    on:
+      tags: true
+      condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
+  - provider: releases
+    file: /tmp/json-schema/mustachetemplate_*.json
     skip_cleanup: true
     api_key: "${GITHUB_TOKEN}"
     name: "${TRAVIS_TAG}"


### PR DESCRIPTION
`kubeconform` can validate CRD schemas, but only if they have been converted to JSON. they provide a python tool for converting CRD yamls to the correct JSON spec.

this commit adds CI to do that conversion and publish the result as a github release asset for public consumption